### PR TITLE
Fix Forgot Password Flow: Treat email addresses as case insensitive

### DIFF
--- a/source/console/app/common/services/AuthService.js
+++ b/source/console/app/common/services/AuthService.js
@@ -23,7 +23,7 @@ angular.module('dataLake.service.auth', ['dataLake.utils'])
         this.signup = function(newuser) {
             var deferred = $q.defer();
 
-            newuser.username = newuser.email.replace('@', '_').replace(/\./g, '_');
+            newuser.username = newuser.email.replace('@', '_').replace(/\./g, '_').toLowerCase();
 
             var poolData = {
                 UserPoolId: YOUR_USER_POOL_ID,
@@ -74,7 +74,7 @@ angular.module('dataLake.service.auth', ['dataLake.utils'])
         this.newPassword = function(newuser) {
             var deferred = $q.defer();
 
-            newuser.username = newuser.email.replace('@', '_').replace(/\./g, '_');
+            newuser.username = newuser.email.replace('@', '_').replace(/\./g, '_').toLowerCase();
 
             var poolData = {
                 UserPoolId: YOUR_USER_POOL_ID,
@@ -96,7 +96,7 @@ angular.module('dataLake.service.auth', ['dataLake.utils'])
         this.forgot = function(user) {
             var deferred = $q.defer();
 
-            var _username = user.email.replace('@', '_').replace(/\./g, '_');
+            var _username = user.email.replace('@', '_').replace(/\./g, '_').toLowerCase();
             console.log(_username);
 
             var poolData = {
@@ -129,7 +129,7 @@ angular.module('dataLake.service.auth', ['dataLake.utils'])
         this.resetPassword = function(user) {
             var deferred = $q.defer();
 
-            var _username = user.email.replace('@', '_').replace(/\./g, '_');
+            var _username = user.email.replace('@', '_').replace(/\./g, '_').toLowerCase();
 
             var poolData = {
                 UserPoolId: YOUR_USER_POOL_ID,

--- a/source/console/app/search/search_test.js
+++ b/source/console/app/search/search_test.js
@@ -49,9 +49,12 @@ describe('dataLake.search module', function() {
         });
 
         it('should return results when searching', function() {
+            // Use `moment` here as result is dependent on local timezone
+            var name = ['test package', '[', moment('2016-11-01T12:00:00Z').format('M/D/YYYY hh:mm:ss A'), ']'].join(' ');
+            
             $scope.search('myterm');
             expect($scope.results[0]).toEqual({
-                name: 'test package [ 11/1/2016 08:00:00 AM ]',
+                name: name,
                 description: 'description for test item',
                 updated_at: '2016-11-01T12:00:00Z'
             });


### PR DESCRIPTION
**The Problem**
In many companies, when copying an email address out of Outlook it will contain capital letters.  E.g. `First.Last@company.com`

When inviting/register a new user with capital letters in the email address, these capital letters are maintained when deriving the Cognito username for the user.  Later if the user uses the forgot password function and types their email address without capital letters the receive an error because the derived username cannot be found.

**The Fix**
Whenever the email address is used to derive the Cognito username for the user the email address is converted to lower case first (i.e. treat the email as case insensitive).