### PR TITLE
Fix issue #53 about InvalidBucketAclWithObjectOwnership

### DIFF
--- a/deployment/data-lake-deploy-federated.template
+++ b/deployment/data-lake-deploy-federated.template
@@ -483,6 +483,9 @@ Resources:
                 BlockPublicPolicy: true
                 IgnorePublicAcls: true
                 RestrictPublicBuckets: true
+            OwnershipControls:
+                Rules:
+                  - ObjectOwnership: BucketOwnerPreferred
 
     ConsoleCFDistribution:
         DependsOn:

--- a/deployment/data-lake-deploy.template
+++ b/deployment/data-lake-deploy.template
@@ -490,6 +490,9 @@ Resources:
                 BlockPublicPolicy: true
                 IgnorePublicAcls: true
                 RestrictPublicBuckets: true
+            OwnershipControls:
+                Rules:
+                  - ObjectOwnership: BucketOwnerPreferred
 
     ConsoleCFDistribution:
         DependsOn:


### PR DESCRIPTION
*Issue #53 *

The CloudFormation stack fails to create the S3 bucket "S3LoggingBucket", with the following error:

`Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership). `

*Description of changes:*
Because ACLs are enabled (AccessControl: LogDeliveryWrite), then Object Ownership must be set with Bucket owner preferred.
"AccessControl" is actually a legacy property and not recommended any longer for most use cases, except in unusual circumstances where you must control access for each object individually.

Therefore, if the AccessControl property is disabled, the object ownership will be for the bucket owner enforced by default. If we remove "AccessControl" property, the resource is created successfully.

Hope this is helpful! Thank you.

References:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol
https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html


-- I copied/pasted the code fix from the issue by @fecmcd